### PR TITLE
Memory leaks elimination, rand_double fix, rand_range refactoring

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -993,15 +993,20 @@ void cleanup_vulkan(void) {
 	vkx_cleanup_instance();
 }
 
-double rand_double(double max) {
-	return ((double)rand() / (double)RAND_MAX) * max;
+double rand_double(double exclusive_max) {
+	for (;;) {
+		double result = ((double)rand() / (double)RAND_MAX) * exclusive_max;
+		if (result < exclusive_max) {
+			return result;
+		}
+	}
 }
 
-int rand_range(int min, int max) {
+int rand_range(int min, int exclusive_max) {
 	/*
-	 * Return a random number between min and max
+	 * Return a random number between min and exclusive max
 	 */
-	return (int)((double)rand() / ((double)RAND_MAX + 1) * (max - min) + min);
+	return min + (int)rand_double((double)(exclusive_max - min));
 }
 
 size_t get_tile_index(size_t x, size_t y) {

--- a/src/main.c
+++ b/src/main.c
@@ -408,6 +408,7 @@ void init_vulkan(void) {
 		"shaders/screen.frag.spv"
 	);
 
+	free(sprite_attribute_descriptions);
 	free(attribute_descriptions);
 
 	

--- a/src/vkx/vkx_init.c
+++ b/src/vkx/vkx_init.c
@@ -42,10 +42,12 @@ static bool vkx_check_validation_layer_support() {
 		}
 
 		if (!layer_found) {
+			free(available_layers);
 			return false;
 		}
 	}
 
+	free(available_layers);
 	return true;
 }
 
@@ -68,7 +70,9 @@ static char const * const * vkx_get_required_extensions(uint32_t* count) {
 	}
 	
 	if (!enable_validation_layers) {
-		return sdl_extensions;
+		const char** extensions = malloc(sizeof(const char*) * *count);
+		memcpy(extensions, sdl_extensions, sizeof(const char*) * *count);
+		return extensions;
 	}
 
 	// If validation layers are enabled, add the debug utils extension
@@ -248,6 +252,8 @@ void vkx_init(SDL_Window* window) {
 		fprintf(stderr, "failed to create instance!");
 		exit(1);
 	}
+
+	free((void *)instance_create_info.ppEnabledExtensionNames);
 
 	// ----- Create the debug messenger -----
 	if (enable_validation_layers) {


### PR DESCRIPTION
I used Valgrind for memory leaks detection and their elimination validation.

Additonally tested using `enable_validation_layers = false;` in `vkx_init.c`.

And here

```
const char** extensions = malloc(sizeof(const char*) * *count);
memcpy(extensions, sdl_extensions, sizeof(const char*) * *count);
return extensions;
```

in `vkx_ini.c` I introduced returning a copy of `sdl_extensions` so the result of `vkx_get_required_extensions` may be freed disregarding whether `SDL_Vulkan_GetInstanceExtensions` is used or not. Because `sdl_extensions` returned from `SDL_Vulkan_GetInstanceExtensions` is not supposed to be freed:

```
You should not free the returned array; it is owned by SDL.
```

https://wiki.libsdl.org/SDL3/SDL_Vulkan_GetInstanceExtensions