### PR TITLE
Corrections in shaders: add missing mvps, fix texSampler size, replace magic numbers with defines, hide unused uniforms

### DIFF
--- a/shaders/screen.frag
+++ b/shaders/screen.frag
@@ -1,7 +1,9 @@
 #version 450
+#define NUM_MONSTERS 1000
 
 layout(binding = 0) uniform UniformBufferObject {
     float t;
+    mat4 mvps[NUM_MONSTERS];
 } ubo;
 
 layout(binding = 1) uniform sampler2D tex_sampler;

--- a/shaders/sprite.frag
+++ b/shaders/sprite.frag
@@ -1,11 +1,8 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
+#define NUM_TEXTURES 5
 
-layout(binding = 0) uniform UniformBufferObject {
-    float t;
-	mat4 mvps[1000];
-} ubo;
-layout(binding = 1) uniform sampler2D texSampler[2];
+layout(binding = 1) uniform sampler2D texSampler[NUM_TEXTURES];
 
 layout(location = 0) in vec4 frag_color;
 layout(location = 1) in vec2 frag_tex_coord;

--- a/shaders/sprite.vert
+++ b/shaders/sprite.vert
@@ -1,8 +1,9 @@
 #version 450
+#define NUM_MONSTERS 1000
 
 layout(binding = 0) uniform UniformBufferObject {
     float t;
-	mat4 mvps[1000];
+	mat4 mvps[NUM_MONSTERS];
 } ubo;
 
 layout(location = 0) in vec4 color_in;

--- a/shaders/tiles.frag
+++ b/shaders/tiles.frag
@@ -1,6 +1,7 @@
 #version 450
+#define NUM_TEXTURES 5
 
-layout(binding = 1) uniform sampler2D texSampler[2];
+layout(binding = 1) uniform sampler2D texSampler[NUM_TEXTURES];
 
 layout(push_constant) uniform PushConstantObject {
 	mat4 mvp;

--- a/shaders/tiles.vert
+++ b/shaders/tiles.vert
@@ -1,9 +1,5 @@
 #version 450
 
-layout(binding = 0) uniform UniformBufferObject {
-    float t;
-} ubo;
-
 layout(push_constant) uniform PushConstantObject {
 	mat4 mvp;
 	vec4 color;

--- a/src/main.c
+++ b/src/main.c
@@ -1184,7 +1184,7 @@ void create_monsters(void) {
 			for (size_t k=0; k<4; k++) {
 				vertex_sprites[idx].color[k] = monsters[i].color[k];
 			}
-			// Calculate uv index base on 8x8 grid of sprites
+			// Calculate uv index based on 4x4 grid of sprites
 			size_t sprite_x = i % 4;
 			size_t sprite_y = (i % 16) / 4;
 			float uv_scale = 1.0f / 4.0f;


### PR DESCRIPTION
Though the shaders work as is, I see 2 mistakes.

In `screen.frag` and `tiles.vert` there is no `mat4 mvps[1000];` in `ubo`:

```
layout(binding = 0) uniform UniformBufferObject {
    float t;
} ubo;
```

In `sprite.frag` and `tiles.frag` size 2 is wrong for `texSampler`:

```
layout(binding = 1) uniform sampler2D texSampler[2];
```

In addition to eliminating the mistakes, I removed some unused uniforms and replaced magic numbers 1000 and 5 with defines `NUM_MONSTERS` and `NUM_TEXTURES` accordingly.