### PR TITLE
Fix synchronization validation errors, edit comments, add SDL_SyncWindow

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -536,7 +536,6 @@ void init_vulkan(void) {
 		ds_alloc_info.descriptorSetCount = VKX_FRAMES_IN_FLIGHT;
 		ds_alloc_info.pSetLayouts = ds_layouts;
 		
-		// Create the base descriptor sets
 		if (vkAllocateDescriptorSets(vkx_instance.device, &ds_alloc_info, descriptor_sets) != VK_SUCCESS) {
 			fprintf(stderr, "failed to allocate descriptor sets!\n");
 			exit(1);
@@ -595,7 +594,6 @@ void init_vulkan(void) {
 		ds_alloc_info.descriptorSetCount = VKX_FRAMES_IN_FLIGHT;
 		ds_alloc_info.pSetLayouts = ds_layouts;
 		
-		// Create the base descriptor sets
 		if (vkAllocateDescriptorSets(vkx_instance.device, &ds_alloc_info, screen_descriptor_sets) != VK_SUCCESS) {
 			fprintf(stderr, "failed to allocate screen descriptor sets!\n");
 			exit(1);

--- a/src/main.c
+++ b/src/main.c
@@ -478,7 +478,7 @@ void init_vulkan(void) {
 			VK_IMAGE_ASPECT_COLOR_BIT
 		);
 
-		// transition the image layout to color attachment optimal
+		// transition the image layout to shader read
 		vkx_transition_image_layout_tmp_buffer(
 			offscreen_images[i].image,
 			vkx_swap_chain.image_format,
@@ -680,7 +680,7 @@ void record_command_buffer(VkCommandBuffer command_buffer, uint32_t image_index)
 		VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
 	);
 
-	// Memory barrier to transition the offscreen image from color attachment to shader read
+	// Memory barrier to transition the offscreen image from shader read to color attachment
 	vkx_transition_image_layout(
 		command_buffer,
 		offscreen_images[current_frame].image,
@@ -799,7 +799,7 @@ void record_command_buffer(VkCommandBuffer command_buffer, uint32_t image_index)
 
 	vkCmdEndRendering(command_buffer);
 
-	// Memory barrier to transition the offscreen image from shader read to color attachment
+	// Memory barrier to transition the offscreen image from color attachment to shader read
 	vkx_transition_image_layout(
 		command_buffer,
 		offscreen_images[current_frame].image,
@@ -836,7 +836,7 @@ void record_command_buffer(VkCommandBuffer command_buffer, uint32_t image_index)
 	// --- End dynamic rendering ----------------------------------------------
 	vkCmdEndRendering(command_buffer);
 	
-	// Memory barrier to transition the swap chain image from color attachment to present
+	// Memory barrier to transition the swap chain image from color attachment to present source
 	vkx_transition_image_layout(
 		command_buffer,
 		vkx_swap_chain.images[image_index],

--- a/src/main.c
+++ b/src/main.c
@@ -1313,6 +1313,7 @@ int main(void) {
 						SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
 						fullscreen = true;
 					}
+					SDL_SyncWindow(window);
 					framebuffer_resized = true;
 				}
 			}

--- a/src/vkx/vkx_core.c
+++ b/src/vkx/vkx_core.c
@@ -366,8 +366,8 @@ void vkx_transition_image_layout(
 	}
 	else if (old_layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
 			&& new_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
-		barrier.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		barrier.srcAccessMask = 0;
+		barrier.srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
 		barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 		barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 	}
@@ -380,9 +380,9 @@ void vkx_transition_image_layout(
 	}
 	else if (old_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
 			&& new_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
-		barrier.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		barrier.srcAccessMask = 0;
-		barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		barrier.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+		barrier.dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 		barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
 	}
 	else if (old_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL


### PR DESCRIPTION
1. Fixed synchronization validation errors.

I set the environment variable `VK_VALIDATION_VALIDATE_SYNC=1` and got synchronization validation error messages.

After realizing that they come from `vkx_transition_image_layout` calls, I located which calls trigger errors. I did it by temporarily changing access and stage masks the following way

```
barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
barrier.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
```

inside `vkx_transition_image_layout` for every pair of `old_layout` and `new_layout` until all the synchronization validation error messages were gone. This way I located 2 cases giving synchronization validation error messages:

```
	else if (old_layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
			&& new_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
		barrier.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
		barrier.srcAccessMask = 0;
		barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
		barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
```

and

```
	else if (old_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
			&& new_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
		barrier.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
		barrier.srcAccessMask = 0;
		barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
		barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
```

Then I looked around for what values of access and stage masks should be used in those cases. When fixing the first case, I used the symmetric (where old layout and new layout are swapped) case

```
	else if (old_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
			&& new_layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
		barrier.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
		barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
		barrier.dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
		barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
	}
```

as a reference. When fixing the second case, I used the symmetric case

```
	else if (old_layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
			&& new_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
		barrier.srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
		barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
		barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
		barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
	}
```

as a reference. Then synchronization validation error messages do not appear on my side anymore with the environment variable `VK_VALIDATION_VALIDATE_SYNC=1` set.

2. Corrected a few comments to `vkx_transition_image_layout`.

3. Removed confusing comments `// Create the base descriptor sets`. They are identical and probably wrong. Right few lines above them there are already comments `// ----- Create the descriptor sets -----` and `// ----- Create the screen descriptor sets -----`.

4. Added `SDL_SyncWindow` after `SDL_SetWindowFullscreen`.

When you toggle the fullscreen mode, you may notice that after the message

```
Framebuffer resized - recreating swap chain
```

there are messages

```
Swapchain was suboptimal
Swapchain is still suboptimal - recreating
```

because the window may be not yet resized by the time the swapchain is recreated after toggling the fullscreen mode. So then the swapchain is recreated again by the time the window is really resized. It happens because `SDL_SetWindowFullscreen` is asynchronous. After adding `SDL_SyncWindow`, the swapchain becomes recreated just once after toggling the fullscreen mode.